### PR TITLE
Only trigger onerror when there is actually an error.

### DIFF
--- a/src/ping.js
+++ b/src/ping.js
@@ -17,9 +17,17 @@ Ping.prototype.ping = function(source, callback, timeout) {
     var timer;
 
     var start = new Date();
-    this.img.onload = this.img.onerror = pingCheck;
+    this.img.onload = pingCheck;
+    this.img.onerror = pingError;
     if (timeout) { timer = setTimeout(pingCheck, timeout); }
 
+    /**
+     * Does not resolve.
+     */
+    function pingError() {
+      callback("Error");
+    }
+    
     /**
      * Times ping and triggers callback.
      */
@@ -32,5 +40,5 @@ Ping.prototype.ping = function(source, callback, timeout) {
         }
     }
 
-    this.img.src = source + "/?" + (+new Date()); // Trigger image load with cache buster
+    this.img.src = source + "/favicon.ico?" + (+new Date()); // Trigger image load with cache buster
 };


### PR DESCRIPTION
onError is always triggered unless the image actually exists. Most websites have favicon.ico, so this will cause onError to only be triggered when there is actually an error... like in the case the website DNS doesn't resolve (`net::ERR_NAME_NOT_RESOLVED`).

I know favicon.ico is not guaranteed to exist, but this addresses https://github.com/alfg/ping.js/issues/7 and https://github.com/alfg/ping.js/issues/13

http://jsfiddle.net/12z14qk9/